### PR TITLE
.denoflare config schema: Allow Trailing Commas

### DIFF
--- a/common/config.schema.json
+++ b/common/config.schema.json
@@ -4,6 +4,7 @@
     "title": "Denoflare configuration file",
     "description": "Top-level Denoflare configuration object",
     "type": "object",
+    "allowTrailingCommas": true,
     "properties": {
         "scripts": {
             "description": "Known script definitions, by unique `script-name`.",


### PR DESCRIPTION
Adding this will prevent vscode from warning on trailing commas