### PR TITLE
Update deno_graph version from 0.18.0 to 0.41.0

### DIFF
--- a/cli/deps_cli.ts
+++ b/cli/deps_cli.ts
@@ -1,8 +1,8 @@
 export { basename, dirname, join, fromFileUrl, resolve, toFileUrl, extname, relative, isAbsolute, normalize, parse as parsePath, globToRegExp } from 'https://deno.land/std@0.171.0/path/mod.ts';
 export { ensureDir, walk, emptyDir } from 'https://deno.land/std@0.171.0/fs/mod.ts';
 export { SEP as systemSeparator } from 'https://deno.land/std@0.171.0/path/separator.ts';
-export { createGraph } from 'https://deno.land/x/deno_graph@0.18.0/mod.ts';
-export type { ModuleGraphJson } from 'https://deno.land/x/deno_graph@0.18.0/lib/types.d.ts';
+export { createGraph } from 'https://deno.land/x/deno_graph@0.41.0/mod.ts';
+export type { ModuleGraphJson } from 'https://deno.land/x/deno_graph@0.41.0/lib/types.d.ts';
 export { gzip } from 'https://deno.land/x/compress@v0.4.1/zlib/mod.ts';
 export { parse as _parseJsonc } from 'https://cdn.skypack.dev/jsonc-parser@3.0.0';
 export { default as marked } from 'https://cdn.skypack.dev/marked@3.0.2?dts';


### PR DESCRIPTION
Previous version of "deno_graph" did not work offline. This is because the wasm module is constantly fetching from remote sources. and I found that in version 0.41.0 this problem has been resolved