### PR TITLE
fix(kv): add correct response from list endpoint for kv

### DIFF
--- a/cli/api_kv_namespace.ts
+++ b/cli/api_kv_namespace.ts
@@ -95,7 +95,12 @@ export class ApiKVNamespace implements KVNamespace {
     async list(opts?: KVListOptions): Promise<KVListCompleteResult | KVListIncompleteResult> {
         const { accountId, namespaceId, apiToken } = this;
 
-        return await listKeys({ accountId, namespaceId, apiToken, ...opts });
-    }
+        const response = await listKeys({ accountId, namespaceId, apiToken, ...opts });
 
+        return {
+            keys: response.result,
+            list_complete: Boolean(response.result_info.cursor),
+            cursor: response.result_info.cursor
+        }
+    }
 }

--- a/common/cloudflare_api.ts
+++ b/common/cloudflare_api.ts
@@ -396,7 +396,22 @@ export async function listKeys(opts: { accountId: string, namespaceId: string, a
     if (cursor) url.searchParams.set('cursor', cursor);
     if (prefix) url.searchParams.set('prefix', prefix);
 
-    return (await execute<KVListCompleteResult | KVListIncompleteResult>('listKeys', 'GET', url.toString(), apiToken)).result;
+    const response = await execute('listKeys', 'GET', url.toString(), apiToken) as KVApiListResult;
+
+    return {
+        keys: response.result,
+        list_complete: Boolean(response.result_info.cursor),
+        cursor: response.result_info.cursor
+    }
+}
+
+export interface ResultInfoKV {
+    count: number;
+    cursor: string;
+}
+
+export interface ListKVResponse extends CloudflareApiResponse<KVListCompleteResult | KVListIncompleteResult> {
+    readonly result_info: ResultInfoKV;
 }
 
 //#endregion

--- a/common/cloudflare_api.ts
+++ b/common/cloudflare_api.ts
@@ -396,21 +396,21 @@ export async function listKeys(opts: { accountId: string, namespaceId: string, a
     if (cursor) url.searchParams.set('cursor', cursor);
     if (prefix) url.searchParams.set('prefix', prefix);
 
-    const response = await execute('listKeys', 'GET', url.toString(), apiToken) as KVApiListResult;
+    return await execute('listKeys', 'GET', url.toString(), apiToken) as ListKVResponse;
+}
 
-    return {
-        keys: response.result,
-        list_complete: Boolean(response.result_info.cursor),
-        cursor: response.result_info.cursor
-    }
+export interface ResultListKV {
+    readonly expiration: number;
+    readonly metadata: Record<string, string>;
+    readonly name: string;
 }
 
 export interface ResultInfoKV {
-    count: number;
-    cursor: string;
+    readonly count: number;
+    readonly cursor: string;
 }
 
-export interface ListKVResponse extends CloudflareApiResponse<KVListCompleteResult | KVListIncompleteResult> {
+export interface ListKVResponse extends CloudflareApiResponse<ResultListKV[]> {
     readonly result_info: ResultInfoKV;
 }
 


### PR DESCRIPTION
Just correcting the list endpoint as it wasn't compliant with the correct output from the workers SDK but rather only the API.
(In my case this differences made a whole difference)

Is there any way that I can run the formatting on my side or a guide to format it properly?