### PR TITLE
Upgrade default version of esbuild-deno-loader

### DIFF
--- a/cli/bundle.ts
+++ b/cli/bundle.ts
@@ -122,7 +122,7 @@ export async function bundle(rootSpecifier: string, opts: BundleOpts = {}): Prom
                 configPath = await Deno.makeTempFile({ prefix: 'denoflare-esbuild-bundle', suffix: '.json'});
                 await Deno.writeTextFile(configPath, JSON.stringify({ compilerOptions }));
             }
-            const { loader = 'native', loaderModule = '^0.10.3', esbuildModule = '0.23.0', ...unknownOptions } = rest;
+            const { loader = 'native', loaderModule = '^0.11.0', esbuildModule = '0.23.0', ...unknownOptions } = rest;
             if (Object.keys(unknownOptions).length > 0) throw new Error(`Unknown esbuild bundler option${Object.keys(unknownOptions).length === 1 ? '' : 's'}: ${JSON.stringify(unknownOptions)}`);
 
             if (loader !== 'native' && loader !== 'portable') throw new Error(`Invalid esbuild loader: expected 'native' or 'portable'`);


### PR DESCRIPTION
Why?

* esbuild-deno-loader@0.11.0 auto resolves `deno.json` imports and supports deno 2.0
* https://github.com/lucacasonato/esbuild_deno_loader/releases/tag/0.11.0

With this change, denoflare can support import aliases declared in the deno.json out of the box. Which simplies the experience for new users, currently, they need to run

```
denoflare serve my-script --bundle 'loaderModule=^0.11.0'
```

example of imports map

```
   // deno.json ...
  "imports": {
   "@custom/": "./src/example/custom",
    "@std/assert": "jsr:@std/assert@^1.0.8"
  }

```

