### PR TITLE
Replace deprecated durable_objects_active with active

### DIFF
--- a/common/cloudflare_api.ts
+++ b/common/cloudflare_api.ts
@@ -2827,7 +2827,7 @@ export type ContainersApplication = ContainersApplicationInput & {
     active_rollout_id?: string,
     health?: {
         instances: {
-            durable_objects_active: number,
+            active: number,
             healthy: number,
             failed: number,
             starting: number,


### PR DESCRIPTION
The "durable_objects_active" field is deprecated and about to be removed. It's been replaced by "active".